### PR TITLE
Fix module loading and documentation link

### DIFF
--- a/docs/en-US/ImpliedReflection.md
+++ b/docs/en-US/ImpliedReflection.md
@@ -1,0 +1,27 @@
+---
+Module Name: ImpliedReflection
+Module Guid: 8834a5bf-9bf2-4f09-8415-3c1e561109f6 8834a5bf-9bf2-4f09-8415-3c1e561109f6
+Download Help Link:
+Help Version: 1.0.0
+Locale: en-US
+---
+
+# ImpliedReflection Module
+
+## Description
+
+Explore private properties and methods as if they were public.
+
+## ImpliedReflection Cmdlets
+
+### [Add-PrivateMember](Add-PrivateMember.md)
+
+The Add-PrivateMember function binds all non-public members to an object in the same way the PowerShell engine binds public members. This allows the members to be viewed and invoked like any other property or method typically bound by PowerShell.  Properties will be added as PSProperty objects and Methods will be bound as PSMethod objects.
+
+### [Disable-ImpliedReflection](Disable-ImpliedReflection.md)
+
+The Disable-ImpliedReflection function will disable the binding of non-public members to any object outputted to the console.
+
+### [Enable-ImpliedReflection](Enable-ImpliedReflection.md)
+
+The Enable-ImpliedReflection function replaces the Out-Default cmdlet with a proxy function that invokes Add-PrivateMember on every object outputted to the console.

--- a/module/ImpliedReflection.psd1
+++ b/module/ImpliedReflection.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ImpliedReflection.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.0'
+ModuleVersion = '0.1.1'
 
 # ID used to uniquely identify this module
 GUID = '8834a5bf-9bf2-4f09-8415-3c1e561109f6'
@@ -80,7 +80,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        # ReleaseNotes = ''
+        ReleaseNotes = '- Fixed the module not loading.'
 
     } # End of PSData hashtable
 

--- a/module/ImpliedReflection.psm1
+++ b/module/ImpliedReflection.psm1
@@ -1,7 +1,7 @@
 Import-LocalizedData -BindingVariable Strings -FileName Strings -ErrorAction Ignore
 
 # Include all function files.
-Get-ChildItem $PSScriptRoot\Public\*.ps1, $PSScriptRoot\Private\*.ps1 | ForEach-Object {
+Get-ChildItem $PSScriptRoot\Public\*.ps1 | ForEach-Object {
     . $PSItem.FullName
 }
 


### PR DESCRIPTION
- Fixed an issue where the module loading would fail due to an empty directory not being included in the package.

- Added the module landing page to the documentation.  (Thank you @Rick-2CA!)