### PR TITLE
Fix Add-PrivateMember

### DIFF
--- a/src/ImpliedReflection/Cache.cs
+++ b/src/ImpliedReflection/Cache.cs
@@ -8,6 +8,13 @@ namespace ImpliedReflection
 {
     internal static class Cache
     {
+        public static ConstructorInfo RuntimeException_ctor = typeof(RuntimeException).
+            GetConstructor(
+                Bind.Public.Instance,
+                binder: null,
+                new[] { typeof(string) },
+                modifiers: null);
+
         public static MethodInfo PropertyInfo_GetGetMethod = typeof(PropertyInfo)
             .GetMethod(
                 nameof(PropertyInfo.GetGetMethod),

--- a/src/ImpliedReflection/Commands/AddPrivateMemberCommand.cs
+++ b/src/ImpliedReflection/Commands/AddPrivateMemberCommand.cs
@@ -48,15 +48,17 @@ namespace ImpliedReflection.Commands
 
             foreach (PSMemberInfo member in memberTable.Members)
             {
-                InputObject.Members.Add(member, preValidated: true);
-                if (member is PSPropertyInfo property)
+                PSMemberInfo clonedMember = member.Clone();
+                clonedMember.ReplicateInstance(InputObject.BaseObject);
+                InputObject.Members.Add(clonedMember, preValidated: true);
+                if (clonedMember is PSPropertyInfo property)
                 {
-                    InputObject.Properties.Add(property, preValidated: true);
+                    InputObject.Properties.Add(property.Clone(), preValidated: true);
                 }
 
-                if (member is PSMethodInfo method)
+                if (clonedMember is PSMethodInfo method)
                 {
-                    InputObject.Methods.Add(method, preValidated: true);
+                    InputObject.Methods.Add(method.Clone(), preValidated: true);
                 }
             }
 

--- a/src/ImpliedReflection/PSMemberInfoExtensions.cs
+++ b/src/ImpliedReflection/PSMemberInfoExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Management.Automation;
+using System.Runtime.CompilerServices;
+
+namespace ImpliedReflection
+{
+    internal static class PSMemberInfoExtensions
+    {
+        private static readonly Action<PSMemberInfo, object> s_replicateInstance;
+
+        public static readonly CallSite<Action<CallSite, PSMemberInfo, object>> s_callsite
+            = CallSite<Action<CallSite, PSMemberInfo, object>>.Create(ReplicateInstanceBinder.Instance);
+
+        public static TMemberInfo Clone<TMemberInfo>(this TMemberInfo member)
+            where TMemberInfo : PSMemberInfo
+        {
+            return (TMemberInfo)member.Copy();
+        }
+
+        public static void ReplicateInstance(this PSMemberInfo member, object instance)
+            => s_callsite.Update(s_callsite, member, instance);
+    }
+}

--- a/src/ImpliedReflection/ReplicateInstanceBinder.cs
+++ b/src/ImpliedReflection/ReplicateInstanceBinder.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Dynamic;
+using System.Reflection;
+
+using BindFlags = ImpliedReflection.Bind;
+
+using static System.Linq.Expressions.Expression;
+using System.Runtime.CompilerServices;
+using System.Management.Automation;
+using System.Linq.Expressions;
+
+namespace ImpliedReflection
+{
+    internal class ReplicateInstanceBinder : InvokeMemberBinder
+    {
+        public readonly static ReplicateInstanceBinder Instance = new ReplicateInstanceBinder();
+
+        private ReplicateInstanceBinder()
+            : base(nameof(PSMemberInfoExtensions.ReplicateInstance), ignoreCase: false, new CallInfo(1, "instance"))
+        {
+        }
+
+        public override DynamicMetaObject FallbackInvoke(
+            DynamicMetaObject target,
+            DynamicMetaObject[] args,
+            DynamicMetaObject errorSuggestion)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override DynamicMetaObject FallbackInvokeMember(
+            DynamicMetaObject target,
+            DynamicMetaObject[] args,
+            DynamicMetaObject errorSuggestion)
+        {
+            Type type = target.RuntimeType;
+            MethodInfo method = type.GetMethod(
+                VersionSpecificMemberNames.PrivateMemberNames.PSMemberInfo_ReplicateInstance,
+                BindFlags.Any.Instance,
+                null,
+                new[] { typeof(object) },
+                null);
+
+            if (method == null)
+            {
+                return new DynamicMetaObject(
+                    Block(
+                        Throw(New(Cache.RuntimeException_ctor, Constant(ImpliedReflectionStrings.InvalidMemberInfo))),
+                        Default(typeof(object))),
+                    BindingRestrictions.GetTypeRestriction(target.Expression, type));
+            }
+
+            Expression instance = Convert(target.Expression, type);
+            Expression callExpr = Call(instance, method, args[0].Expression);
+
+            if (typeof(PSProperty).IsAssignableFrom(type))
+            {
+                // PSProperty doesn't override ReplicateInstance, so the call doesn't actually change
+                // it's private baseObject field.
+                FieldInfo baseObject = typeof(PSProperty).GetField(
+                    nameof(baseObject),
+                    BindFlags.NonPublic.Instance);
+
+                return new DynamicMetaObject(
+                    Block(callExpr, Assign(Field(instance, baseObject), args[0].Expression), Default(typeof(object))),
+                    BindingRestrictions.GetTypeRestriction(target.Expression, type));
+            }
+
+            return new DynamicMetaObject(
+                Block(callExpr, Default(typeof(object))),
+                BindingRestrictions.GetTypeRestriction(target.Expression, type));
+        }
+    }
+}

--- a/src/ImpliedReflection/VersionSpecificMemberNames.cs
+++ b/src/ImpliedReflection/VersionSpecificMemberNames.cs
@@ -178,5 +178,10 @@
         /// Gets a string similar to "CollectionNameForTracing".
         /// </summary>
         public virtual string CollectionEntry_CollectionNameForTracing => "CollectionNameForTracing";
+
+        /// <summary>
+        /// Gets a string similar to "ReplicateInstance".
+        /// </summary>
+        public virtual string PSMemberInfo_ReplicateInstance => "ReplicateInstance";
     }
 }

--- a/src/ImpliedReflection/resources/ImpliedReflectionStrings.resx
+++ b/src/ImpliedReflection/resources/ImpliedReflectionStrings.resx
@@ -137,4 +137,7 @@ This can have unintended consequences, are you sure you want to continue?</value
   <data name="UnknownPowerShellVersion" xml:space="preserve">
     <value>Unable to determine the current PowerShell version. If this is a custom build of PowerShell, please file a GitHub issue for guidance.</value>
   </data>
+  <data name="InvalidMemberInfo" xml:space="preserve">
+    <value>An attempt to clone a PSMemberInfo object failed because no suitable "ReplicateInstance" method was found.</value>
+  </data>
 </root>


### PR DESCRIPTION
The instances were not being changed correctly on cloned member infoobjects.  This change adds a DLR binder to properly update instances.